### PR TITLE
fix(ci): GEMINI_API_KEY no step de testes e atualização do pipeline

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
 
       - name: Cache do Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -32,10 +32,17 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Build com Gradle
-        run: ./gradlew assembleDebug
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: ./gradlew assembleDebug -PGEMINI_API_KEY=$GEMINI_API_KEY
 
       - name: Rodar testes unitários
-        run: ./gradlew testDebugUnitTest
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: ./gradlew testDebugUnitTest -PGEMINI_API_KEY=$GEMINI_API_KEY
+
+      - name: Lint
+        run: ./gradlew lint
 
       - name: Upload de relatórios de teste
         if: always()
@@ -43,6 +50,13 @@ jobs:
         with:
           name: test-results
           path: '**/build/reports/tests/testDebugUnitTest'
+
+      - name: Upload do relatório de lint
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results
+          path: '**/build/reports/lint-results-debug.html'
 
       - name: Gerar relatório de cobertura Jacoco
         run: ./gradlew jacocoTestReport
@@ -53,3 +67,9 @@ jobs:
         with:
           name: code-coverage-report
           path: app/build/reports/jacoco/jacocoTestReport/html
+
+      - name: Upload do APK debug
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,10 @@ val localProperties = Properties().apply {
     rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use { load(it) }
 }
 
+fun geminiApiKey(): String =
+    (project.findProperty("GEMINI_API_KEY") as? String)?.takeIf { it.isNotBlank() }
+        ?: localProperties.getProperty("GEMINI_API_KEY", "")
+
 android {
     namespace = "com.bina.rickandmorty"
     compileSdk = 35
@@ -23,7 +27,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "GEMINI_API_KEY", "\"${localProperties.getProperty("GEMINI_API_KEY", "")}\"")
+        buildConfigField("String", "GEMINI_API_KEY", "\"${geminiApiKey()}\"")
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary

- Passa `GEMINI_API_KEY` como env var e projeto property `-P` no step `testDebugUnitTest`
- Extrai função `geminiApiKey()` em `app/build.gradle.kts` para ler da propriedade de projeto (CI) ou do `local.properties` (dev local)
- Atualiza `actions/cache` de v3 para v4
- Adiciona step de `lint` com upload do relatório
- Adiciona step de upload do APK debug

Sem o repasse da chave no step de testes, o Gradle podia recompilar o `BuildConfig` com chave vazia após o `assembleDebug`.

## Test plan

- [ ] CI executa `testDebugUnitTest` com a chave disponível no `BuildConfig`
- [x] `assembleDebug` e `testDebugUnitTest` leem a mesma chave sem recompilação

🤖 Generated with [Claude Code](https://claude.com/claude-code)