### PR TITLE
fix(core:network): adiciona dependências de teste retrofit-moshi e moshi

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -49,4 +49,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(kotlin("test"))
     testImplementation(libs.mockwebserver)
+    testImplementation(libs.retrofit.moshi)
+    testImplementation(libs.moshi)
+    testImplementation(libs.moshi.kotlin)
 }


### PR DESCRIPTION
## Summary
- `NetworkClientTest` usa `MoshiConverterFactory` e `Moshi` mas `retrofit2:converter-moshi` não estava declarado como `testImplementation` em `core/network/build.gradle.kts`
- Adicionadas três entradas de `testImplementation`: `retrofit.moshi`, `moshi`, `moshi-kotlin`

## Test plan
- [ ] `./gradlew :core:network:testDebugUnitTest` deve compilar e passar sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)