### PR TITLE
docs: adiciona relatório de cobertura Jacoco no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ We enforce the **Given-When-Then** pattern to ensure tests are readable and serv
 - **UI Tests**: Isolated component testing via Compose Testing library.
 - **Turbine**: Leveraged for robust `Flow` and `StateFlow` validation.
 
+### Coverage Report (Unit Tests)
+
+| Module | Lines | Branches | Methods |
+|---|---|---|---|
+| `core:network` | 60.0% (24/40) | 100.0% (14/14) | 78.6% (11/14) |
+| `core:navigation` | 50.0% (3/6) | — | 37.5% (3/8) |
+| `feature:chat` | 87.2% (136/156) | 80.0% (48/60) | 83.8% (67/80) |
+| `feature:character_details` | 96.6% (140/145) | 66.7% (4/6) | 92.0% (80/87) |
+| `feature:home` | 90.8% (109/120) | 37.5% (9/24) | 88.9% (56/63) |
+| **Total** | **88.2%** (412/467) | **72.1%** (75/104) | **86.1%** (217/252) |
+
+> Generated with Jacoco. Run `./gradlew :<module>:jacocoTestReport` to refresh.
+
 ### Design System & Tokens
 The UI is built upon a **Token-based Design System**. 
 - No hardcoded margins or colors in features. 
@@ -158,8 +171,11 @@ ChatScreen (Compose)
 # Run unit tests across all modules
 ./gradlew test
 
-# Generate Jacoco coverage report
-./gradlew jacocoTestReport
+# Generate Jacoco coverage report (single module)
+./gradlew :<module>:jacocoTestReport
+
+# Generate aggregated coverage report for all modules
+./gradlew jacocoFullReport
 
 # Build debug APK
 ./gradlew assembleDebug

--- a/core/network/src/test/java/com/bina/network/interceptor/ResilienceInterceptorTest.kt
+++ b/core/network/src/test/java/com/bina/network/interceptor/ResilienceInterceptorTest.kt
@@ -1,0 +1,151 @@
+package com.bina.network.interceptor
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ResilienceInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    // initialDelay = 0 para os testes não esperarem backoff real
+    private val interceptor = ResilienceInterceptor(maxRetries = 3, initialDelay = 0L)
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun get(): okhttp3.Response {
+        val request = Request.Builder().url(server.url("/test")).build()
+        return client.newCall(request).execute()
+    }
+
+    @Test
+    fun `GIVEN 200 response WHEN intercept THEN returns immediately without retry`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = get()
+
+        assertEquals(200, response.code)
+        assertEquals(1, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 404 response WHEN intercept THEN does not retry`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val response = get()
+
+        assertEquals(404, response.code)
+        assertEquals(1, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 429 then 200 WHEN intercept THEN retries once and returns 200`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = get()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 503 then 200 WHEN intercept THEN retries once and returns 200`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = get()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 500 always WHEN intercept THEN retries maxRetries times then returns 500`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        val response = get()
+
+        assertEquals(500, response.code)
+        // 1 tentativa original + 3 retries = 4 requisições
+        assertEquals(4, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 429 twice then 200 WHEN intercept THEN retries twice and returns 200`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = get()
+
+        assertEquals(200, response.code)
+        assertEquals(3, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN Retry-After header WHEN intercept THEN uses header value for wait time`() {
+        // Com initialDelay=0 e Retry-After=0, o sleep é 0ms — só verifica que não quebra
+        server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "0"))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = get()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 301 redirect code WHEN intercept THEN does not retry`() {
+        server.enqueue(MockResponse().setResponseCode(301))
+
+        val response = get()
+
+        // OkHttp segue redirects por padrão; verificamos que não houve retry pelo interceptor
+        assertEquals(1, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun `GIVEN 429 with maxRetries 1 WHEN intercept THEN retries exactly once`() {
+        val singleRetryInterceptor = ResilienceInterceptor(maxRetries = 1, initialDelay = 0L)
+        val singleRetryClient = OkHttpClient.Builder()
+            .addInterceptor(singleRetryInterceptor)
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val request = Request.Builder().url(server.url("/test")).build()
+        val response = singleRetryClient.newCall(request).execute()
+
+        assertEquals(429, response.code)
+        assertEquals(2, server.requestCount)
+        response.close()
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/data/datasource/EpisodeDataSourceImplTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/data/datasource/EpisodeDataSourceImplTest.kt
@@ -1,0 +1,53 @@
+package com.bina.character_details.data.datasource
+
+import com.bina.character_details.data.model.EpisodeData
+import com.bina.character_details.data.remote.EpisodeApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// ADR-010: a API retorna objeto único (não array) quando há apenas um ID
+class EpisodeDataSourceImplTest {
+
+    private val api: EpisodeApiService = mockk()
+    private val dataSource = EpisodeDataSourceImpl(api)
+
+    private fun episodeData(id: Int = 1) =
+        EpisodeData(id = id, name = "Pilot", episode = "S01E01", airDate = "December 2, 2013")
+
+    @Test
+    fun `GIVEN single id WHEN getEpisodes THEN calls getEpisodeSingle`() = runTest {
+        coEvery { api.getEpisodeSingle(1) } returns episodeData(1)
+
+        val result = dataSource.getEpisodes(listOf(1))
+
+        assertEquals(1, result.size)
+        assertEquals(1, result[0].id)
+        coVerify(exactly = 1) { api.getEpisodeSingle(1) }
+        coVerify(exactly = 0) { api.getEpisodes(any()) }
+    }
+
+    @Test
+    fun `GIVEN multiple ids WHEN getEpisodes THEN calls getEpisodes with comma-separated ids`() = runTest {
+        coEvery { api.getEpisodes("1,2,3") } returns listOf(episodeData(1), episodeData(2), episodeData(3))
+
+        val result = dataSource.getEpisodes(listOf(1, 2, 3))
+
+        assertEquals(3, result.size)
+        coVerify(exactly = 1) { api.getEpisodes("1,2,3") }
+        coVerify(exactly = 0) { api.getEpisodeSingle(any()) }
+    }
+
+    @Test
+    fun `GIVEN two ids WHEN getEpisodes THEN calls getEpisodes not getEpisodeSingle`() = runTest {
+        coEvery { api.getEpisodes("5,10") } returns listOf(episodeData(5), episodeData(10))
+
+        val result = dataSource.getEpisodes(listOf(5, 10))
+
+        assertEquals(2, result.size)
+        coVerify(exactly = 0) { api.getEpisodeSingle(any()) }
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/data/mapper/CharacterDetailsMapperTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/data/mapper/CharacterDetailsMapperTest.kt
@@ -1,0 +1,69 @@
+package com.bina.character_details.data.mapper
+
+import com.bina.character_details.data.model.CharacterDetailsData
+import com.bina.character_details.data.model.LocationDetailsData
+import com.bina.character_details.data.model.OriginData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CharacterDetailsMapperTest {
+
+    private fun data(
+        id: Int = 1,
+        name: String = "Rick Sanchez",
+        status: String = "Alive",
+        species: String = "Human",
+        gender: String = "Male",
+        originName: String = "Earth (C-137)",
+        locationName: String = "Citadel of Ricks",
+        image: String = "https://img.png",
+        episodes: List<String> = listOf("https://rickandmortyapi.com/api/episode/1")
+    ) = CharacterDetailsData(
+        id = id, name = name, status = status, species = species,
+        type = "", gender = gender,
+        origin = OriginData(originName, ""),
+        location = LocationDetailsData(locationName, ""),
+        image = image, episode = episodes, url = "", created = ""
+    )
+
+    @Test
+    fun `GIVEN character data WHEN toDomain THEN all scalar fields are mapped`() {
+        val domain = CharacterDetailsMapper.toDomain(data())
+
+        assertEquals(1, domain.id)
+        assertEquals("Rick Sanchez", domain.name)
+        assertEquals("Alive", domain.status)
+        assertEquals("Human", domain.species)
+        assertEquals("Male", domain.gender)
+        assertEquals("https://img.png", domain.image)
+    }
+
+    @Test
+    fun `GIVEN character data WHEN toDomain THEN origin extracted from nested OriginData`() {
+        val domain = CharacterDetailsMapper.toDomain(data(originName = "Earth (C-137)"))
+
+        assertEquals("Earth (C-137)", domain.origin)
+    }
+
+    @Test
+    fun `GIVEN character data WHEN toDomain THEN location extracted from nested LocationDetailsData`() {
+        val domain = CharacterDetailsMapper.toDomain(data(locationName = "Citadel of Ricks"))
+
+        assertEquals("Citadel of Ricks", domain.location)
+    }
+
+    @Test
+    fun `GIVEN character data with episode urls WHEN toDomain THEN episodeUrls are preserved`() {
+        val urls = listOf("https://rickandmortyapi.com/api/episode/1", "https://rickandmortyapi.com/api/episode/2")
+        val domain = CharacterDetailsMapper.toDomain(data(episodes = urls))
+
+        assertEquals(urls, domain.episodeUrls)
+    }
+
+    @Test
+    fun `GIVEN character with no episodes WHEN toDomain THEN episodeUrls is empty`() {
+        val domain = CharacterDetailsMapper.toDomain(data(episodes = emptyList()))
+
+        assertEquals(emptyList<String>(), domain.episodeUrls)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/data/mapper/EpisodeMapperTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/data/mapper/EpisodeMapperTest.kt
@@ -1,0 +1,29 @@
+package com.bina.character_details.data.mapper
+
+import com.bina.character_details.data.model.EpisodeData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EpisodeMapperTest {
+
+    @Test
+    fun `GIVEN episode data WHEN toDomain THEN all fields are mapped`() {
+        val data = EpisodeData(id = 1, name = "Pilot", episode = "S01E01", airDate = "December 2, 2013")
+
+        val domain = EpisodeMapper.toDomain(data)
+
+        assertEquals(1, domain.id)
+        assertEquals("Pilot", domain.name)
+        assertEquals("S01E01", domain.code)
+        assertEquals("December 2, 2013", domain.airDate)
+    }
+
+    @Test
+    fun `GIVEN episode data WHEN toDomain THEN episode field maps to code`() {
+        val data = EpisodeData(id = 5, name = "Meeseeks and Destroy", episode = "S01E05", airDate = "January 6, 2014")
+
+        val domain = EpisodeMapper.toDomain(data)
+
+        assertEquals("S01E05", domain.code)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/data/repository/CharacterDetailsRepositoryImplTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/data/repository/CharacterDetailsRepositoryImplTest.kt
@@ -1,0 +1,46 @@
+package com.bina.character_details.data.repository
+
+import com.bina.character_details.data.datasource.CharacterDetailsDataSource
+import com.bina.character_details.data.model.CharacterDetailsData
+import com.bina.character_details.data.model.LocationDetailsData
+import com.bina.character_details.data.model.OriginData
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CharacterDetailsRepositoryImplTest {
+
+    private val dataSource: CharacterDetailsDataSource = mockk()
+    private val repository = CharacterDetailsRepositoryImpl(dataSource)
+
+    private fun characterData(id: Int = 1, name: String = "Rick") = CharacterDetailsData(
+        id = id, name = name, status = "Alive", species = "Human",
+        type = "", gender = "Male",
+        origin = OriginData("Earth", ""),
+        location = LocationDetailsData("Earth", ""),
+        image = "img", episode = emptyList(), url = "", created = ""
+    )
+
+    @Test
+    fun `GIVEN dataSource returns data WHEN getCharacterDetails THEN maps and returns domain`() = runTest {
+        coEvery { dataSource.getCharacterDetails(1) } returns characterData(id = 1, name = "Rick Sanchez")
+
+        val result = repository.getCharacterDetails(1)
+
+        assertEquals(1, result.id)
+        assertEquals("Rick Sanchez", result.name)
+        coVerify(exactly = 1) { dataSource.getCharacterDetails(1) }
+    }
+
+    @Test
+    fun `GIVEN dataSource throws WHEN getCharacterDetails THEN exception propagates`() = runTest {
+        coEvery { dataSource.getCharacterDetails(any()) } throws RuntimeException("Not found")
+
+        val exception = runCatching { repository.getCharacterDetails(99) }.exceptionOrNull()
+
+        assertEquals("Not found", exception?.message)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/data/repository/EpisodeRepositoryImplTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/data/repository/EpisodeRepositoryImplTest.kt
@@ -1,0 +1,53 @@
+package com.bina.character_details.data.repository
+
+import com.bina.character_details.data.datasource.EpisodeDataSource
+import com.bina.character_details.data.model.EpisodeData
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EpisodeRepositoryImplTest {
+
+    private val dataSource: EpisodeDataSource = mockk()
+    private val repository = EpisodeRepositoryImpl(dataSource)
+
+    private fun episodeData(id: Int = 1, name: String = "Pilot") =
+        EpisodeData(id = id, name = name, episode = "S01E01", airDate = "December 2, 2013")
+
+    @Test
+    fun `GIVEN dataSource returns episodes WHEN getEpisodes THEN all are mapped to domain`() = runTest {
+        val ids = listOf(1, 2)
+        coEvery { dataSource.getEpisodes(ids) } returns listOf(
+            episodeData(1, "Pilot"),
+            episodeData(2, "Lawnmower Dog")
+        )
+
+        val result = repository.getEpisodes(ids)
+
+        assertEquals(2, result.size)
+        assertEquals("Pilot", result[0].name)
+        assertEquals("Lawnmower Dog", result[1].name)
+        coVerify(exactly = 1) { dataSource.getEpisodes(ids) }
+    }
+
+    @Test
+    fun `GIVEN dataSource returns empty list WHEN getEpisodes THEN returns empty list`() = runTest {
+        coEvery { dataSource.getEpisodes(emptyList()) } returns emptyList()
+
+        val result = repository.getEpisodes(emptyList())
+
+        assertEquals(emptyList<Any>(), result)
+    }
+
+    @Test
+    fun `GIVEN dataSource throws WHEN getEpisodes THEN exception propagates`() = runTest {
+        coEvery { dataSource.getEpisodes(any()) } throws RuntimeException("Network error")
+
+        val exception = runCatching { repository.getEpisodes(listOf(1)) }.exceptionOrNull()
+
+        assertEquals("Network error", exception?.message)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/domain/usecase/GetEpisodesUseCaseTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/domain/usecase/GetEpisodesUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.bina.character_details.domain.usecase
+
+import com.bina.character_details.domain.model.EpisodeDomain
+import com.bina.character_details.domain.repository.EpisodeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetEpisodesUseCaseTest {
+
+    private val repository: EpisodeRepository = mockk()
+    private val useCase = GetEpisodesUseCase(repository)
+
+    @Test
+    fun `GIVEN ids WHEN invoke THEN delegates to repository and returns list`() = runTest {
+        val ids = listOf(1, 2)
+        val expected = listOf(
+            EpisodeDomain(1, "Pilot", "S01E01", "December 2, 2013"),
+            EpisodeDomain(2, "Lawnmower Dog", "S01E02", "December 9, 2013")
+        )
+        coEvery { repository.getEpisodes(ids) } returns expected
+
+        val result = useCase(ids)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { repository.getEpisodes(ids) }
+    }
+
+    @Test
+    fun `GIVEN empty list WHEN invoke THEN returns empty list`() = runTest {
+        coEvery { repository.getEpisodes(emptyList()) } returns emptyList()
+
+        val result = useCase(emptyList())
+
+        assertEquals(emptyList<EpisodeDomain>(), result)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/presentation/mapper/CharacterDetailsUiMapperTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/presentation/mapper/CharacterDetailsUiMapperTest.kt
@@ -1,0 +1,37 @@
+package com.bina.character_details.presentation.mapper
+
+import com.bina.character_details.domain.model.CharacterDetailsDomain
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CharacterDetailsUiMapperTest {
+
+    private val mapper = CharacterDetailsUiMapper()
+
+    private fun domain(
+        id: Int = 1, name: String = "Morty Smith", status: String = "Alive",
+        species: String = "Human", gender: String = "Male",
+        origin: String = "Earth", location: String = "Earth", image: String = "img"
+    ) = CharacterDetailsDomain(id, name, status, species, gender, origin, location, image, emptyList())
+
+    @Test
+    fun `GIVEN domain WHEN map THEN all fields are mapped to UI model`() {
+        val ui = mapper.map(domain())
+
+        assertEquals(1, ui.id)
+        assertEquals("Morty Smith", ui.name)
+        assertEquals("Alive", ui.status)
+        assertEquals("Human", ui.species)
+        assertEquals("Male", ui.gender)
+        assertEquals("Earth", ui.origin)
+        assertEquals("Earth", ui.location)
+        assertEquals("img", ui.imageUrl)
+    }
+
+    @Test
+    fun `GIVEN domain with unknown gender WHEN map THEN gender is preserved`() {
+        val ui = mapper.map(domain(gender = "unknown"))
+
+        assertEquals("unknown", ui.gender)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/presentation/mapper/EpisodeUiMapperTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/presentation/mapper/EpisodeUiMapperTest.kt
@@ -1,0 +1,22 @@
+package com.bina.character_details.presentation.mapper
+
+import com.bina.character_details.domain.model.EpisodeDomain
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EpisodeUiMapperTest {
+
+    private val mapper = EpisodeUiMapper()
+
+    @Test
+    fun `GIVEN domain episode WHEN map THEN all fields are mapped`() {
+        val domain = EpisodeDomain(id = 1, name = "Pilot", code = "S01E01", airDate = "December 2, 2013")
+
+        val ui = mapper.map(domain)
+
+        assertEquals(1, ui.id)
+        assertEquals("Pilot", ui.name)
+        assertEquals("S01E01", ui.code)
+        assertEquals("December 2, 2013", ui.airDate)
+    }
+}

--- a/feature/character_details/src/test/java/com/bina/character_details/presentation/viewmodel/CharacterDetailsViewModelTest.kt
+++ b/feature/character_details/src/test/java/com/bina/character_details/presentation/viewmodel/CharacterDetailsViewModelTest.kt
@@ -2,11 +2,13 @@ package com.bina.character_details.presentation.viewmodel
 
 import app.cash.turbine.test
 import com.bina.character_details.domain.model.CharacterDetailsDomain
+import com.bina.character_details.domain.model.EpisodeDomain
 import com.bina.character_details.domain.usecase.GetCharacterDetailsUseCase
 import com.bina.character_details.domain.usecase.GetEpisodesUseCase
 import com.bina.character_details.presentation.mapper.CharacterDetailsUiMapper
 import com.bina.character_details.presentation.mapper.EpisodeUiMapper
 import com.bina.character_details.presentation.state.CharacterDetailsUiState
+import com.bina.character_details.presentation.state.EpisodesState
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -85,6 +87,95 @@ class CharacterDetailsViewModelTest {
             val state = expectMostRecentItem()
             assert(state is CharacterDetailsUiState.Error)
             assertEquals(errorMessage, (state as CharacterDetailsUiState.Error).message)
+        }
+    }
+
+    @Test
+    fun `GIVEN character with episodes WHEN getCharacterDetails THEN episodesState is Success`() = runTest {
+        val id = 1
+        val characterDomain = CharacterDetailsDomain(
+            id = 1, name = "Rick", status = "Alive", species = "Human", gender = "Male",
+            origin = "Earth", location = "Earth", image = "url",
+            episodeUrls = listOf(
+                "https://rickandmortyapi.com/api/episode/1",
+                "https://rickandmortyapi.com/api/episode/2"
+            )
+        )
+        val episodes = listOf(
+            EpisodeDomain(1, "Pilot", "S01E01", "December 2, 2013"),
+            EpisodeDomain(2, "Lawnmower Dog", "S01E02", "December 9, 2013")
+        )
+        coEvery { getCharacterDetailsUseCase(id) } returns characterDomain
+        coEvery { getEpisodesUseCase(listOf(1, 2)) } returns episodes
+
+        viewModel.getCharacterDetails(id)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as CharacterDetailsUiState.Success
+            assert(state.episodesState is EpisodesState.Success)
+            assertEquals(2, (state.episodesState as EpisodesState.Success).episodes.size)
+            assertEquals("Pilot", (state.episodesState as EpisodesState.Success).episodes[0].name)
+        }
+    }
+
+    @Test
+    fun `GIVEN episodes use case throws WHEN getCharacterDetails THEN episodesState is Error`() = runTest {
+        val id = 1
+        val characterDomain = CharacterDetailsDomain(
+            id = 1, name = "Rick", status = "Alive", species = "Human", gender = "Male",
+            origin = "Earth", location = "Earth", image = "url",
+            episodeUrls = listOf("https://rickandmortyapi.com/api/episode/1")
+        )
+        coEvery { getCharacterDetailsUseCase(id) } returns characterDomain
+        coEvery { getEpisodesUseCase(listOf(1)) } throws RuntimeException("Episodes error")
+
+        viewModel.getCharacterDetails(id)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as CharacterDetailsUiState.Success
+            assert(state.episodesState is EpisodesState.Error)
+            assertEquals("Episodes error", (state.episodesState as EpisodesState.Error).message)
+        }
+    }
+
+    @Test
+    fun `GIVEN character with no episodes WHEN getCharacterDetails THEN episodesState is Success with empty list`() = runTest {
+        val id = 1
+        val characterDomain = CharacterDetailsDomain(
+            id = 1, name = "Rick", status = "Alive", species = "Human", gender = "Male",
+            origin = "Earth", location = "Earth", image = "url",
+            episodeUrls = emptyList()
+        )
+        coEvery { getCharacterDetailsUseCase(id) } returns characterDomain
+        coEvery { getEpisodesUseCase(emptyList()) } returns emptyList()
+
+        viewModel.getCharacterDetails(id)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as CharacterDetailsUiState.Success
+            assert(state.episodesState is EpisodesState.Success)
+            assertEquals(0, (state.episodesState as EpisodesState.Success).episodes.size)
+        }
+    }
+
+    @Test
+    fun `GIVEN episode url WHEN getCharacterDetails THEN id is parsed from url path`() = runTest {
+        val id = 1
+        val characterDomain = CharacterDetailsDomain(
+            id = 1, name = "Rick", status = "Alive", species = "Human", gender = "Male",
+            origin = "Earth", location = "Earth", image = "url",
+            episodeUrls = listOf("https://rickandmortyapi.com/api/episode/42")
+        )
+        coEvery { getCharacterDetailsUseCase(id) } returns characterDomain
+        coEvery { getEpisodesUseCase(listOf(42)) } returns listOf(
+            EpisodeDomain(42, "Total Rickall", "S02E04", "August 30, 2015")
+        )
+
+        viewModel.getCharacterDetails(id)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as CharacterDetailsUiState.Success
+            assertEquals("Total Rickall", (state.episodesState as EpisodesState.Success).episodes[0].name)
         }
     }
 }

--- a/feature/home/src/test/java/com/bina/home/data/mapper/CharacterMapperTest.kt
+++ b/feature/home/src/test/java/com/bina/home/data/mapper/CharacterMapperTest.kt
@@ -1,0 +1,50 @@
+package com.bina.home.data.mapper
+
+import com.bina.home.data.model.CharacterData
+import com.bina.home.data.model.LocationData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CharacterMapperTest {
+
+    private fun characterData(
+        id: Int = 1,
+        name: String = "Rick Sanchez",
+        status: String = "Alive",
+        species: String = "Human",
+        image: String = "https://img.png",
+        locationName: String = "Earth"
+    ) = CharacterData(id, name, status, species, image, LocationData(locationName, ""))
+
+    @Test
+    fun `GIVEN character data WHEN toDomain THEN all fields are mapped correctly`() {
+        val data = characterData()
+
+        val domain = CharacterMapper.toDomain(data)
+
+        assertEquals(1, domain.id)
+        assertEquals("Rick Sanchez", domain.name)
+        assertEquals("Alive", domain.status)
+        assertEquals("Human", domain.species)
+        assertEquals("https://img.png", domain.image)
+        assertEquals("Earth", domain.location)
+    }
+
+    @Test
+    fun `GIVEN character data WHEN toDomain THEN location is extracted from nested LocationData name`() {
+        val data = characterData(locationName = "Citadel of Ricks")
+
+        val domain = CharacterMapper.toDomain(data)
+
+        assertEquals("Citadel of Ricks", domain.location)
+    }
+
+    @Test
+    fun `GIVEN dead character WHEN toDomain THEN status is preserved`() {
+        val data = characterData(status = "Dead")
+
+        val domain = CharacterMapper.toDomain(data)
+
+        assertEquals("Dead", domain.status)
+    }
+}

--- a/feature/home/src/test/java/com/bina/home/data/repository/CharacterPagingSourceTest.kt
+++ b/feature/home/src/test/java/com/bina/home/data/repository/CharacterPagingSourceTest.kt
@@ -1,6 +1,8 @@
 package com.bina.home.data.repository
 
+import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
+import androidx.paging.PagingState
 import com.bina.home.data.datasource.CharacterDataSource
 import com.bina.home.data.model.CharacterData
 import com.bina.home.data.model.LocationData
@@ -57,6 +59,50 @@ class CharacterPagingSourceTest {
         val error = result as PagingSource.LoadResult.Error
         assertEquals("API error", error.throwable.message)
         coVerify { dataSource.getCharacters("", 1) }
+    }
+
+    @Test
+    fun `GIVEN null key WHEN load THEN defaults to page 1`() = runTest {
+        val characters = listOf(CharacterData(1, "Rick", "Alive", "Human", "img", LocationData("Earth", "")))
+        coEvery { dataSource.getCharacters("", 1) } returns characters
+
+        val result = pagingSource.load(PagingSource.LoadParams.Refresh(key = null, loadSize = 20, placeholdersEnabled = false))
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        coVerify { dataSource.getCharacters("", 1) }
+    }
+
+    @Test
+    fun `GIVEN empty results WHEN load THEN nextKey is null`() = runTest {
+        coEvery { dataSource.getCharacters("", 1) } returns emptyList()
+
+        val result = pagingSource.load(PagingSource.LoadParams.Refresh(key = 1, loadSize = 20, placeholdersEnabled = false))
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        val page = result as PagingSource.LoadResult.Page
+        assertEquals(null, page.nextKey)
+    }
+
+    @Test
+    fun `GIVEN page 2 WHEN load THEN prevKey is 1`() = runTest {
+        val characters = listOf(CharacterData(2, "Morty", "Alive", "Human", "img", LocationData("Earth", "")))
+        coEvery { dataSource.getCharacters("", 2) } returns characters
+
+        val result = pagingSource.load(PagingSource.LoadParams.Refresh(key = 2, loadSize = 20, placeholdersEnabled = false))
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        val page = result as PagingSource.LoadResult.Page
+        assertEquals(1, page.prevKey)
+        assertEquals(3, page.nextKey)
+    }
+
+    @Test
+    fun `GIVEN null anchorPosition WHEN getRefreshKey THEN returns null`() {
+        val state = PagingState<Int, CharacterData>(pages = emptyList(), anchorPosition = null, config = PagingConfig(20), leadingPlaceholderCount = 0)
+
+        val result = pagingSource.getRefreshKey(state)
+
+        assertEquals(null, result)
     }
 }
 

--- a/feature/home/src/test/java/com/bina/home/presentation/mapper/CharacterUiMapperTest.kt
+++ b/feature/home/src/test/java/com/bina/home/presentation/mapper/CharacterUiMapperTest.kt
@@ -1,0 +1,42 @@
+package com.bina.home.presentation.mapper
+
+import com.bina.home.domain.model.CharacterDomain
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CharacterUiMapperTest {
+
+    private val mapper = CharacterUiMapper()
+
+    private fun domain(
+        id: Int = 1,
+        name: String = "Morty Smith",
+        status: String = "Alive",
+        species: String = "Human",
+        image: String = "https://img.png",
+        location: String = "Earth"
+    ) = CharacterDomain(id, name, status, species, image, location)
+
+    @Test
+    fun `GIVEN domain model WHEN map THEN all fields are mapped to UI model`() {
+        val domain = domain()
+
+        val ui = mapper.map(domain)
+
+        assertEquals(1, ui.id)
+        assertEquals("Morty Smith", ui.name)
+        assertEquals("Alive", ui.status)
+        assertEquals("Human", ui.species)
+        assertEquals("https://img.png", ui.imageUrl)
+        assertEquals("Earth", ui.location)
+    }
+
+    @Test
+    fun `GIVEN domain with unknown status WHEN map THEN status is preserved`() {
+        val domain = domain(status = "unknown")
+
+        val ui = mapper.map(domain)
+
+        assertEquals("unknown", ui.status)
+    }
+}

--- a/feature/home/src/test/java/com/bina/home/presentation/viewmodel/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/bina/home/presentation/viewmodel/HomeViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.bina.home.presentation.viewmodel
+
+import androidx.paging.PagingData
+import com.bina.home.domain.model.CharacterDomain
+import com.bina.home.domain.usecase.GetCharactersUseCase
+import com.bina.home.presentation.mapper.CharacterUiMapper
+import com.bina.home.presentation.state.CharactersUiState
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val getCharactersUseCase: GetCharactersUseCase = mockk()
+    private val uiMapper = CharacterUiMapper()
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun defaultPagingFlow() = flowOf(
+        PagingData.from(listOf(CharacterDomain(1, "Rick", "Alive", "Human", "img", "Earth")))
+    )
+
+    private fun createViewModel() = HomeViewModel(getCharactersUseCase, uiMapper)
+
+    @Test
+    fun `GIVEN use case returns data WHEN init THEN state is Success`() = runTest {
+        every { getCharactersUseCase(any()) } returns defaultPagingFlow()
+
+        viewModel = createViewModel()
+
+        assertTrue(viewModel.uiState.value is CharactersUiState.Success)
+    }
+
+    @Test
+    fun `GIVEN init WHEN getCharacters THEN use case is called with empty string`() = runTest {
+        every { getCharactersUseCase("") } returns defaultPagingFlow()
+
+        viewModel = createViewModel()
+
+        coVerify { getCharactersUseCase("") }
+    }
+
+    @Test
+    fun `GIVEN successful init WHEN onQueryChange THEN use case is called with new query`() = runTest {
+        every { getCharactersUseCase(any()) } returns defaultPagingFlow()
+
+        viewModel = createViewModel()
+        viewModel.onQueryChange("Morty")
+
+        coVerify(atLeast = 1) { getCharactersUseCase("Morty") }
+    }
+
+    @Test
+    fun `GIVEN query set WHEN onRetry THEN use case is called again with same query`() = runTest {
+        every { getCharactersUseCase(any()) } returns defaultPagingFlow()
+
+        viewModel = createViewModel()
+        viewModel.onQueryChange("Rick")
+        viewModel.onRetry()
+
+        coVerify(atLeast = 2) { getCharactersUseCase("Rick") }
+    }
+
+    @Test
+    fun `GIVEN state is not Error WHEN clearError THEN state remains unchanged`() = runTest {
+        every { getCharactersUseCase(any()) } returns defaultPagingFlow()
+        viewModel = createViewModel()
+        val stateBefore = viewModel.uiState.value
+
+        viewModel.clearError()
+
+        assertEquals(stateBefore, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `GIVEN multiple queries WHEN onQueryChange THEN each triggers use case with correct query`() = runTest {
+        every { getCharactersUseCase(any()) } returns defaultPagingFlow()
+
+        viewModel = createViewModel()
+        viewModel.onQueryChange("Rick")
+        viewModel.onQueryChange("Morty")
+
+        coVerify(atLeast = 1) { getCharactersUseCase("Rick") }
+        coVerify(atLeast = 1) { getCharactersUseCase("Morty") }
+    }
+}


### PR DESCRIPTION
Adiciona tabela de cobertura por módulo na seção **Quality Assurance** do README com os números gerados pelo Jacoco após as melhorias de testes.

| Module | Lines | Branches | Methods |
|---|---|---|---|
| `core:network` | 60.0% | 100.0% | 78.6% |
| `core:navigation` | 50.0% | — | 37.5% |
| `feature:chat` | 87.2% | 80.0% | 83.8% |
| `feature:character_details` | 96.6% | 66.7% | 92.0% |
| `feature:home` | 90.8% | 37.5% | 88.9% |
| **Total** | **88.2%** | **72.1%** | **86.1%** |

Também corrige os comandos de geração do relatório: `jacocoTestReport` por módulo e `jacocoFullReport` para o relatório agregado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)