### PR TITLE
refactor: corrige 3 problemas de design — UiState, isolamento de módulo e persona

### DIFF
--- a/app/src/main/java/com/bina/rickandmorty/di/Modules.kt
+++ b/app/src/main/java/com/bina/rickandmorty/di/Modules.kt
@@ -7,14 +7,12 @@ import com.bina.home.di.homeModule
 import com.bina.logging.di.loggingModule
 import com.bina.network.NetworkClient
 import com.bina.rickandmorty.BuildConfig
-import com.bina.home.data.remote.RickAndMortyApiService
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import retrofit2.Retrofit
 
 val networkModule = module {
     single<Retrofit> { NetworkClient.retrofit }
-    single<RickAndMortyApiService> { get<Retrofit>().create(RickAndMortyApiService::class.java) }
 }
 
 val keysModule = module {

--- a/feature/chat/src/main/java/com/bina/chat/chat/data/repository/ChatRepositoryImpl.kt
+++ b/feature/chat/src/main/java/com/bina/chat/chat/data/repository/ChatRepositoryImpl.kt
@@ -8,17 +8,10 @@ import com.bina.chat.chat.domain.repository.ChatRepository
 import com.bina.chat.search.data.datasource.CharacterSearchDataSource
 import kotlinx.coroutines.flow.Flow
 
-private const val RICK_PERSONA = """Você é um especialista apaixonado no universo de Rick and Morty.
-Responda com o tom sarcástico, brilhante e impaciente do Rick Sanchez.
-Use gírias do Rick ocasionalmente (como "Morty", "wubba lubba dub dub", "burp").
-Seja direto e um pouco condescendente, mas sempre preciso sobre o universo do show.
-Quando o usuário pedir para VER ou MOSTRAR um personagem específico, use a função show_character.
-Quando o usuário pedir para BUSCAR ou LISTAR personagens por nome, use a função search_characters.
-Responda a seguinte pergunta como Rick responderia: """
-
 class ChatRepositoryImpl(
     private val dataSource: ChatDataSource,
-    private val characterSearch: CharacterSearchDataSource
+    private val characterSearch: CharacterSearchDataSource,
+    private val persona: String
 ) : ChatRepository {
 
     override suspend fun checkAvailability(): ModelAvailability = dataSource.checkAvailability()
@@ -26,10 +19,10 @@ class ChatRepositoryImpl(
     override suspend fun warmup() = dataSource.warmup()
 
     override fun streamResponse(userMessage: String): Flow<String> =
-        dataSource.sendMessageStream(RICK_PERSONA + userMessage)
+        dataSource.sendMessageStream(persona + userMessage)
 
     override suspend fun sendAgentMessage(userMessage: String): AgentMessageResult {
-        val toolResponse = dataSource.sendMessageWithTools(RICK_PERSONA + userMessage)
+        val toolResponse = dataSource.sendMessageWithTools(persona + userMessage)
 
         val navigationEvent = toolResponse.functionCalls.firstOrNull()?.let { call ->
             when (call.name) {

--- a/feature/chat/src/main/java/com/bina/chat/di/ChatModule.kt
+++ b/feature/chat/src/main/java/com/bina/chat/di/ChatModule.kt
@@ -20,6 +20,14 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import retrofit2.Retrofit
 
+private const val RICK_PERSONA = """Você é um especialista apaixonado no universo de Rick and Morty.
+Responda com o tom sarcástico, brilhante e impaciente do Rick Sanchez.
+Use gírias do Rick ocasionalmente (como "Morty", "wubba lubba dub dub", "burp").
+Seja direto e um pouco condescendente, mas sempre preciso sobre o universo do show.
+Quando o usuário pedir para VER ou MOSTRAR um personagem específico, use a função show_character.
+Quando o usuário pedir para BUSCAR ou LISTAR personagens por nome, use a função search_characters.
+Responda a seguinte pergunta como Rick responderia: """
+
 val chatModule = module {
     single<GenerativeModel> {
         val showCharacterFn = defineFunction(
@@ -43,7 +51,7 @@ val chatModule = module {
     single<CharacterSearchApiService> { get<Retrofit>().create(CharacterSearchApiService::class.java) }
     factory<CharacterSearchDataSource> { CharacterSearchDataSourceImpl(get()) }
     factory<ChatDataSource> { ChatDataSourceImpl(get()) }
-    factory<ChatRepository> { ChatRepositoryImpl(get(), get()) }
+    factory<ChatRepository> { ChatRepositoryImpl(get(), get(), RICK_PERSONA) }
     factory { CheckModelAvailabilityUseCase(get()) }
     factory { SendMessageUseCase(get()) }
     factory { ChatMessageUiMapper() }

--- a/feature/chat/src/test/java/com/bina/chat/chat/data/repository/ChatRepositoryImplTest.kt
+++ b/feature/chat/src/test/java/com/bina/chat/chat/data/repository/ChatRepositoryImplTest.kt
@@ -21,7 +21,7 @@ class ChatRepositoryImplTest {
 
     private val dataSource: ChatDataSource = mockk()
     private val characterSearch: CharacterSearchDataSource = mockk()
-    private val repository = ChatRepositoryImpl(dataSource, characterSearch)
+    private val repository = ChatRepositoryImpl(dataSource, characterSearch, "PERSONA: ")
 
     @Test
     fun `GIVEN dataSource returns Available WHEN checkAvailability THEN returns Available`() = runTest {

--- a/feature/home/src/main/java/com/bina/home/di/HomeModule.kt
+++ b/feature/home/src/main/java/com/bina/home/di/HomeModule.kt
@@ -2,6 +2,7 @@ package com.bina.home.di
 
 import com.bina.home.data.datasource.CharacterDataSource
 import com.bina.home.data.datasource.CharacterDataSourceImpl
+import com.bina.home.data.remote.RickAndMortyApiService
 import com.bina.home.data.repository.HomeRepositoryImpl
 import com.bina.home.domain.repository.HomeRepository
 import com.bina.home.domain.usecase.GetCharactersUseCase
@@ -9,8 +10,10 @@ import com.bina.home.presentation.mapper.CharacterUiMapper
 import com.bina.home.presentation.viewmodel.HomeViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
+import retrofit2.Retrofit
 
 val homeModule = module {
+    single<RickAndMortyApiService> { get<Retrofit>().create(RickAndMortyApiService::class.java) }
     factory<CharacterDataSource> { CharacterDataSourceImpl(get()) }
     factory<HomeRepository> { HomeRepositoryImpl(get()) }
     factory { GetCharactersUseCase(get()) }

--- a/feature/home/src/main/java/com/bina/home/presentation/state/CharactersUiState.kt
+++ b/feature/home/src/main/java/com/bina/home/presentation/state/CharactersUiState.kt
@@ -1,11 +1,7 @@
 package com.bina.home.presentation.state
 
-import androidx.paging.PagingData
-import com.bina.home.presentation.model.CharacterUiModel
-import kotlinx.coroutines.flow.Flow
-
 sealed class CharactersUiState {
     object Loading : CharactersUiState()
-    data class Success(val data: Flow<PagingData<CharacterUiModel>>) : CharactersUiState()
+    object Success : CharactersUiState()
     data class Error(val message: String?) : CharactersUiState()
 }

--- a/feature/home/src/main/java/com/bina/home/presentation/view/HomeScreen.kt
+++ b/feature/home/src/main/java/com/bina/home/presentation/view/HomeScreen.kt
@@ -164,7 +164,7 @@ internal fun HomeContent(
     when (uiState) {
         is CharactersUiState.Loading -> LoadingContent(modifier = modifier)
         is CharactersUiState.Success -> {
-            val characters = uiState.data.collectAsLazyPagingItems()
+            val characters = viewModel.characters.collectAsLazyPagingItems()
 
             val previousAppendState = remember { mutableStateOf<LoadState>(LoadState.NotLoading(false)) }
             LaunchedEffect(characters.loadState.append) {

--- a/feature/home/src/main/java/com/bina/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/bina/home/presentation/viewmodel/HomeViewModel.kt
@@ -15,13 +15,14 @@ import com.bina.home.presentation.mapper.CharacterUiMapper
 import com.bina.home.presentation.model.CharacterUiModel
 import com.bina.logging.AppLogger
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -38,6 +39,9 @@ class HomeViewModel(
 
     private val _uiState = MutableStateFlow<CharactersUiState>(CharactersUiState.Loading)
     val uiState: StateFlow<CharactersUiState> = _uiState
+
+    private val _characters = MutableSharedFlow<PagingData<CharacterUiModel>>(replay = 1)
+    val characters: SharedFlow<PagingData<CharacterUiModel>> = _characters
 
     private var currentQuery = ""
     private var screenLoadTracked = false
@@ -105,7 +109,8 @@ class HomeViewModel(
                         logger.info(TAG, "home_screen_load: ${duration}ms")
                         screenLoadTracked = true
                     }
-                    _uiState.value = CharactersUiState.Success(flowOf(mappedPagingData))
+                    _characters.emit(mappedPagingData)
+                    _uiState.value = CharactersUiState.Success
                 }
         }
     }


### PR DESCRIPTION
## Contexto

Análise de qualidade do projeto identificou três problemas de design. Este PR os corrige.

---

## Mudanças

### 1. `Flow<PagingData>` fora do `UiState`

**Problema:** `CharactersUiState.Success` carregava um `Flow` como dado:
```kotlin
// antes — Flow não é um valor, quebra igualdade estrutural
data class Success(val data: Flow<PagingData<CharacterUiModel>>) : CharactersUiState()
```

**Correção:** `Success` virou `object`. `HomeViewModel` expõe `val characters: SharedFlow<PagingData<CharacterUiModel>>` separado, com `replay = 1`. `HomeScreen` coleta `viewModel.characters.collectAsLazyPagingItems()` no branch `Success`.

---

### 2. `:app` importando classe `data` de `:feature:home`

**Problema:** `app/di/Modules.kt` importava e instanciava `RickAndMortyApiService` diretamente, violando o isolamento do módulo.

**Correção:** Binding movido para `homeModule` — único módulo que precisa conhecer o service. O `:app` passa a ser cego à implementação interna da feature.

---

### 3. Persona de agente na camada `data`

**Problema:** `RICK_PERSONA` era uma `private const val` em `ChatRepositoryImpl` (data layer), mas representa uma regra de comportamento do agente.

**Correção:** `ChatRepositoryImpl` recebe `persona: String` no construtor. A const foi movida para `ChatModule` (DI) — onde configuração de aplicação pertence.

---

## Test plan

- [x] `./gradlew :feature:home:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew :feature:chat:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew :feature:home:compileDebugKotlin :feature:chat:compileDebugKotlin :app:compileDebugKotlin` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)