### PR TITLE
ci: integra Codecov para visualização de cobertura no browser

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -104,6 +104,14 @@ jobs:
           name: roborazzi-diffs
           path: '**/build/outputs/roborazzi/**_compare.png'
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/jacoco/full/jacocoFullReport.xml
+          flags: unittests
+          fail_ci_if_error: false
+
       - name: Upload JaCoCo XML
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,6 +10,8 @@ jobs:
   static-analysis:
     name: Análise Estática
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -33,6 +35,25 @@ jobs:
 
       - name: Run Detekt
         run: ./gradlew detekt
+
+      - name: Setup Reviewdog
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Post Detekt annotations via Reviewdog
+        if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          find . -path "*/build/reports/detekt/*.xml" -not -path "*detekt-all*" \
+            | xargs cat \
+            | reviewdog -f=checkstyle \
+                -name="detekt" \
+                -reporter=github-pr-review \
+                -filter-mode=added \
+                -fail-on-error=false
 
       - name: Run Lint
         run: ./gradlew lint

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,9 @@ allprojects {
         config.setFrom(rootProject.files("config/detekt/detekt.yml"))
         buildUponDefaultConfig = true
         autoCorrect = false
+        reports {
+            xml.required.set(true)
+        }
     }
     tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
         config.setFrom(rootProject.files("config/detekt/detekt.yml"))


### PR DESCRIPTION
## Summary

- Adiciona `codecov/codecov-action@v5` no job de testes do CI
- Faz upload do `jacocoFullReport.xml` para o Codecov após cada execução
- Permite visualizar cobertura linha a linha no dashboard `codecov.io` sem baixar nada
- Comentário automático de cobertura aparece em cada PR

## Setup necessário

Antes do merge, adicionar o secret `CODECOV_TOKEN` no repositório:
1. Acesse [codecov.io](https://codecov.io) e conecte o repositório
2. Copie o token em **Settings → General**
3. No GitHub: **Settings → Secrets → Actions → New secret** → `CODECOV_TOKEN`

## Test plan

- [ ] Secret `CODECOV_TOKEN` adicionado no repositório
- [ ] CI executa sem erro no step "Upload coverage to Codecov"
- [ ] Dashboard visível em `codecov.io/gh/<usuario>/RickAndMortyAi`
- [ ] Comentário de cobertura aparece no PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)