### PR TITLE
ci: atualiza actions para v5 e habilita comentário do Codecov em PRs

### DIFF
--- a/.claude/wiki/CI-Qualidade-Continua.md
+++ b/.claude/wiki/CI-Qualidade-Continua.md
@@ -1,0 +1,77 @@
+# CI — Qualidade Contínua
+
+O pipeline de CI roda em todo PR e push para `master`/`develop` via GitHub Actions.
+
+---
+
+## Jobs
+
+### 1. Análise Estática (`static-analysis`)
+
+| Step | O que faz |
+|------|-----------|
+| `./gradlew detekt` | Analisa o código com as regras de `config/detekt/detekt.yml` |
+| Reviewdog | Posta os achados do Detekt como comentários **inline no diff do PR** |
+| `./gradlew lint` | Executa o Android Lint em todos os módulos |
+
+**Reviewdog** só atua em PRs (`filter-mode=added`) — só comenta em linhas que foram alteradas no PR, sem poluir com issues antigas.
+
+### 2. Testes e Cobertura (`test`)
+
+| Step | O que faz |
+|------|-----------|
+| `testDebugUnitTest` | Roda todos os testes unitários |
+| `jacocoTestReport` + `jacocoFullReport` | Gera relatório de cobertura por módulo e agregado |
+| Codecov | Sobe o XML para o [dashboard do Codecov](https://codecov.io/gh/sabinabernardes/RickAndMortyAIAgent) e posta comentário no PR com o link do relatório e diff de cobertura |
+| Roborazzi | Verifica screenshot goldens — falha se houver diff visual |
+
+### 3. Coverage Gate (`coverage-gate`)
+
+Só roda em PRs. Usa `madrapps/jacoco-report` para:
+- Exigir mínimo de **60% de cobertura geral**
+- Exigir mínimo de **60% nos arquivos alterados no PR**
+- Postar comentário com resumo de cobertura
+
+---
+
+## Ferramentas
+
+### Codecov
+
+- **Dashboard**: [codecov.io/gh/sabinabernardes/RickAndMortyAIAgent](https://codecov.io/gh/sabinabernardes/RickAndMortyAIAgent)
+- **O que mostra**: cobertura linha a linha por arquivo, histórico de cobertura, diff entre branches
+- **Secret necessário**: `CODECOV_TOKEN` em _Settings → Secrets → Actions_
+- **Badge token**: obter em _Codecov → Settings → Badge_ (diferente do upload token)
+
+### Reviewdog + Detekt
+
+- Não precisa de token extra — usa o `GITHUB_TOKEN` nativo do Actions
+- Saída XML habilitada em todos os módulos via `allprojects` no `build.gradle.kts`
+- Só comenta em linhas novas/alteradas no PR
+
+---
+
+## Secrets necessários
+
+| Secret | Onde obter | Usado por |
+|--------|------------|-----------|
+| `CODECOV_TOKEN` | codecov.io → Settings → General | Upload de cobertura |
+| `GEMINI_API_KEY` | Google AI Studio | Testes e build |
+| `GITHUB_TOKEN` | Automático (Actions) | Reviewdog, coverage gate |
+
+---
+
+## Versões das Actions
+
+Todas as GitHub Actions usam **v5** (Node.js 24):
+
+```
+actions/checkout@v5
+actions/setup-java@v5
+actions/cache@v5
+actions/upload-artifact@v5
+actions/download-artifact@v5
+codecov/codecov-action@v5
+reviewdog/action-setup@v1
+madrapps/jacoco-report@v1.6.1
+```

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 17 (Zulu)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -60,14 +60,14 @@ jobs:
 
       - name: Upload Detekt report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: detekt-results
           path: '**/build/reports/detekt/detekt.html'
 
       - name: Upload Lint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lint-results
           path: '**/build/reports/lint-results-debug.html'
@@ -75,19 +75,21 @@ jobs:
   test:
     name: Testes e Cobertura
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 17 (Zulu)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -108,7 +110,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: '**/build/reports/tests/testDebugUnitTest'
@@ -120,7 +122,7 @@ jobs:
 
       - name: Upload screenshot diffs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: roborazzi-diffs
           path: '**/build/outputs/roborazzi/**_compare.png'
@@ -132,9 +134,10 @@ jobs:
           files: build/reports/jacoco/full/jacocoFullReport.xml
           flags: unittests
           fail_ci_if_error: false
+          comment: true
 
       - name: Upload JaCoCo XML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: jacoco-xml
           path: build/reports/jacoco/full/jacocoFullReport.xml
@@ -149,10 +152,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download JaCoCo XML
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: jacoco-xml
           path: build/reports/jacoco/full/
@@ -168,4 +171,3 @@ jobs:
           update-comment: true
           pass-emoji: ':green_circle:'
           fail-emoji: ':red_circle:'
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Android CI](https://github.com/sabinabernardes/RickAndMorty/actions/workflows/android-ci.yml/badge.svg)](https://github.com/sabinabernardes/RickAndMorty/actions/workflows/android-ci.yml)
 
+[![codecov](https://codecov.io/gh/sabinabernardes/RickAndMortyAIAgent/graph/badge.svg?token=YOUR_CODECOV_BADGE_TOKEN)](https://codecov.io/gh/sabinabernardes/RickAndMortyAIAgent)
+
 Enterprise-grade Android project demonstrating **Clean Architecture**, **Multi-module**, and **Generative AI** integration. Built as a technical showcase for scalable Android development with Jetpack Compose.
 
 ---
@@ -100,6 +102,7 @@ Documentação completa na [Wiki do repositório](https://github.com/sabinaberna
 | [Testes de UI](https://github.com/sabinabernardes/RickAndMorty/wiki/Testes-de-UI) | Robolectric, createComposeRule e cobertura por módulo |
 | [Screenshot Testing com Roborazzi](.claude/wiki/Screenshot-Testing-Roborazzi.md) | Goldens, record vs verify, dark mode, troubleshooting |
 | [Acessibilidade WCAG 2.1 AA](https://github.com/sabinabernardes/RickAndMorty/wiki/Acessibilidade-WCAG-2.1-AA) | TalkBack, contraste AA, semântica e live regions |
+| [CI — Qualidade Contínua](.claude/wiki/CI-Qualidade-Continua.md) | JaCoCo + Codecov, Detekt + Reviewdog, coverage gate 60% |
 
 ---
 


### PR DESCRIPTION
## Summary

- Atualiza todas as GitHub Actions de v4 para v5 (Node.js 24)
- Adiciona `comment: true` no Codecov — a partir desse PR, cada novo PR vai receber um comentário automático com o link do relatório de cobertura e o diff de cobertura dos arquivos alterados
- Adiciona `permissions: pull-requests: write` no job `test` (necessário para o Codecov postar o comentário)

## Test plan

- [ ] CI passa sem warnings de Node.js 20
- [ ] Comentário do Codecov aparece no PR com link para o relatório

🤖 Generated with [Claude Code](https://claude.com/claude-code)